### PR TITLE
Add export of open file descriptors

### DIFF
--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -96,6 +96,12 @@ var (
 		[]string{"groupname", "memtype"},
 		nil)
 
+	openFDsDesc = prometheus.NewDesc(
+		"namedprocess_namegroup_open_filedesc",
+		"number of open file descriptors for this group",
+		[]string{"groupname"},
+		nil)
+
 	startTimeDesc = prometheus.NewDesc(
 		"namedprocess_namegroup_oldest_start_time_seconds",
 		"start time in seconds since 1970/01/01 of oldest process in group",
@@ -318,6 +324,7 @@ func (p *NamedProcessCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- readBytesDesc
 	ch <- writeBytesDesc
 	ch <- membytesDesc
+	ch <- openFDsDesc
 	ch <- startTimeDesc
 	ch <- scrapeErrorsDesc
 	ch <- scrapePermissionErrorsDesc
@@ -354,6 +361,8 @@ func (p *NamedProcessCollector) scrape(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue, float64(gcounts.Memvirtual), gname, "virtual")
 			ch <- prometheus.MustNewConstMetric(startTimeDesc,
 				prometheus.GaugeValue, float64(gcounts.OldestStartTime.Unix()), gname)
+			ch <- prometheus.MustNewConstMetric(openFDsDesc,
+				prometheus.GaugeValue, float64(gcounts.OpenFDs), gname)
 			ch <- prometheus.MustNewConstMetric(cpuSecsDesc,
 				prometheus.CounterValue, gcounts.Cpu, gname)
 			ch <- prometheus.MustNewConstMetric(readBytesDesc,

--- a/proc/grouper.go
+++ b/proc/grouper.go
@@ -22,6 +22,7 @@ type (
 		Memresident     uint64
 		Memvirtual      uint64
 		OldestStartTime time.Time
+		OpenFDs         uint64
 	}
 )
 
@@ -121,9 +122,10 @@ func (g *Grouper) groups() GroupCountMap {
 		}
 		cur := gcounts[tinfo.GroupName]
 		cur.Procs++
-		_, counts, mem, start := tinfo.GetStats()
+		_, counts, mem, fds, start := tinfo.GetStats()
 		cur.Memresident += mem.Resident
 		cur.Memvirtual += mem.Virtual
+		cur.OpenFDs += fds.Open
 		cur.Counts.Cpu += counts.Cpu
 		cur.Counts.ReadBytes += counts.ReadBytes
 		cur.Counts.WriteBytes += counts.WriteBytes

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -36,8 +36,8 @@ func (s MySuite) TestGrouperBasic(c *C) {
 		}
 	}
 	gr := NewGrouper(false, newNamer("g1", "g2"))
-	p1 := newProc(1, "g1", ProcMetrics{1, 2, 3, 4, 5})
-	p2 := newProc(2, "g2", ProcMetrics{2, 3, 4, 5, 6})
+	p1 := newProc(1, "g1", ProcMetrics{1, 2, 3, 4, 5, 6})
+	p2 := newProc(2, "g2", ProcMetrics{2, 3, 4, 5, 6, 7})
 	p3 := newProc(3, "g3", ProcMetrics{})
 
 	_, err := gr.Update(procInfoIter(p1, p2, p3))
@@ -45,22 +45,22 @@ func (s MySuite) TestGrouperBasic(c *C) {
 
 	got1 := gr.groups()
 	want1 := GroupCountMap{
-		"g1": GroupCounts{Counts{0, 0, 0}, 1, 4, 5, time.Time{}},
-		"g2": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}},
+		"g1": GroupCounts{Counts{0, 0, 0}, 1, 4, 5, time.Time{}, 6},
+		"g2": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}, 7},
 	}
 	c.Check(got1, DeepEquals, want1)
 
 	// Now increment counts and memory and make sure group counts updated.
-	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6}
-	p2.ProcMetrics = ProcMetrics{4, 5, 6, 7, 8}
+	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6, 7}
+	p2.ProcMetrics = ProcMetrics{4, 5, 6, 7, 8, 9}
 
 	_, err = gr.Update(procInfoIter(p1, p2, p3))
 	c.Assert(err, IsNil)
 
 	got2 := gr.groups()
 	want2 := GroupCountMap{
-		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}},
-		"g2": GroupCounts{Counts{2, 2, 2}, 1, 7, 8, time.Time{}},
+		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}, 7},
+		"g2": GroupCounts{Counts{2, 2, 2}, 1, 7, 8, time.Time{}, 9},
 	}
 	c.Check(got2, DeepEquals, want2)
 
@@ -68,29 +68,29 @@ func (s MySuite) TestGrouperBasic(c *C) {
 	// counts for p4 won't be factored into the total yet
 	// because we only add to counts starting with the
 	// second time we see a proc.  Memory is affected though.
-	p4 := newProc(4, "g2", ProcMetrics{1, 1, 1, 1, 1})
-	p2.ProcMetrics = ProcMetrics{5, 6, 7, 8, 9}
+	p4 := newProc(4, "g2", ProcMetrics{1, 1, 1, 1, 1, 1})
+	p2.ProcMetrics = ProcMetrics{5, 6, 7, 8, 9, 10}
 
 	_, err = gr.Update(procInfoIter(p1, p2, p3, p4))
 	c.Assert(err, IsNil)
 
 	got3 := gr.groups()
 	want3 := GroupCountMap{
-		"g1": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}},
-		"g2": GroupCounts{Counts{1, 1, 1}, 2, 9, 10, time.Time{}},
+		"g1": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}, 7},
+		"g2": GroupCounts{Counts{1, 1, 1}, 2, 9, 10, time.Time{}, 11},
 	}
 	c.Check(got3, DeepEquals, want3, Commentf("diff %s", pretty.Compare(got3, want3)))
 
-	p4.ProcMetrics = ProcMetrics{2, 2, 2, 2, 2}
-	p2.ProcMetrics = ProcMetrics{6, 7, 8, 8, 9}
+	p4.ProcMetrics = ProcMetrics{2, 2, 2, 2, 2, 2}
+	p2.ProcMetrics = ProcMetrics{6, 7, 8, 8, 9, 9}
 
 	_, err = gr.Update(procInfoIter(p1, p2, p3, p4))
 	c.Assert(err, IsNil)
 
 	got4 := gr.groups()
 	want4 := GroupCountMap{
-		"g1": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}},
-		"g2": GroupCounts{Counts{2, 2, 2}, 2, 10, 11, time.Time{}},
+		"g1": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}, 7},
+		"g2": GroupCounts{Counts{2, 2, 2}, 2, 10, 11, time.Time{}, 11},
 	}
 	c.Check(got4, DeepEquals, want4, Commentf("diff %s", pretty.Compare(got4, want4)))
 
@@ -118,8 +118,8 @@ func (s MySuite) TestGrouperParents(c *C) {
 
 	got1 := gr.groups()
 	want1 := GroupCountMap{
-		"g1": GroupCounts{Counts{}, 1, 0, 0, time.Time{}},
-		"g2": GroupCounts{Counts{}, 1, 0, 0, time.Time{}},
+		"g1": GroupCounts{Counts{}, 1, 0, 0, time.Time{}, 0},
+		"g2": GroupCounts{Counts{}, 1, 0, 0, time.Time{}, 0},
 	}
 	c.Check(got1, DeepEquals, want1, Commentf("diff %s", pretty.Compare(got1, want1)))
 
@@ -135,8 +135,8 @@ func (s MySuite) TestGrouperParents(c *C) {
 
 	got2 := gr.groups()
 	want2 := GroupCountMap{
-		"g1": GroupCounts{Counts{}, 2, 0, 0, time.Time{}},
-		"g2": GroupCounts{Counts{}, 2, 0, 0, time.Time{}},
+		"g1": GroupCounts{Counts{}, 2, 0, 0, time.Time{}, 0},
+		"g2": GroupCounts{Counts{}, 2, 0, 0, time.Time{}, 0},
 	}
 	c.Check(got2, DeepEquals, want2, Commentf("diff %s", pretty.Compare(got2, want2)))
 
@@ -151,8 +151,8 @@ func (s MySuite) TestGrouperParents(c *C) {
 
 	got3 := gr.groups()
 	want3 := GroupCountMap{
-		"g1": GroupCounts{Counts{}, 1, 0, 0, time.Time{}},
-		"g2": GroupCounts{Counts{}, 5, 0, 0, time.Time{}},
+		"g1": GroupCounts{Counts{}, 1, 0, 0, time.Time{}, 0},
+		"g2": GroupCounts{Counts{}, 5, 0, 0, time.Time{}, 0},
 	}
 	c.Check(got3, DeepEquals, want3, Commentf("diff %s", pretty.Compare(got3, want3)))
 }
@@ -171,23 +171,23 @@ func (s MySuite) TestGrouperGroup(c *C) {
 	gr := NewGrouper(false, newNamer("g1"))
 
 	// First call should return zero CPU/IO.
-	p1 := newProc(1, "g1", ProcMetrics{1, 2, 3, 4, 5})
+	p1 := newProc(1, "g1", ProcMetrics{1, 2, 3, 4, 5, 6})
 	_, err := gr.Update(procInfoIter(p1))
 	c.Assert(err, IsNil)
 	got1 := gr.Groups()
 	want1 := GroupCountMap{
-		"g1": GroupCounts{Counts{0, 0, 0}, 1, 4, 5, time.Time{}},
+		"g1": GroupCounts{Counts{0, 0, 0}, 1, 4, 5, time.Time{}, 6},
 	}
 	c.Check(got1, DeepEquals, want1)
 
 	// Second call should return the delta CPU/IO from first observance,
 	// as well as latest memory/proccount.
-	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6}
+	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6, 7}
 	_, err = gr.Update(procInfoIter(p1))
 	c.Assert(err, IsNil)
 	got2 := gr.Groups()
 	want2 := GroupCountMap{
-		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}},
+		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}, 7},
 	}
 	c.Check(got2, DeepEquals, want2)
 
@@ -196,7 +196,7 @@ func (s MySuite) TestGrouperGroup(c *C) {
 	c.Assert(err, IsNil)
 	got3 := gr.Groups()
 	want3 := GroupCountMap{
-		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}},
+		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}, 7},
 	}
 	c.Check(got3, DeepEquals, want3, Commentf("diff %s", pretty.Compare(got3, want3)))
 }
@@ -213,54 +213,54 @@ func (s MySuite) TestGrouperNonDecreasing(c *C) {
 		}
 	}
 	gr := NewGrouper(false, newNamer("g1", "g2"))
-	p1 := newProc(1, "g1", ProcMetrics{1, 2, 3, 4, 5})
-	p2 := newProc(2, "g2", ProcMetrics{2, 3, 4, 5, 6})
+	p1 := newProc(1, "g1", ProcMetrics{1, 2, 3, 4, 5, 6})
+	p2 := newProc(2, "g2", ProcMetrics{2, 3, 4, 5, 6, 7})
 
 	_, err := gr.Update(procInfoIter(p1, p2))
 	c.Assert(err, IsNil)
 
 	got1 := gr.Groups()
 	want1 := GroupCountMap{
-		"g1": GroupCounts{Counts{0, 0, 0}, 1, 4, 5, time.Time{}},
-		"g2": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}},
+		"g1": GroupCounts{Counts{0, 0, 0}, 1, 4, 5, time.Time{}, 6},
+		"g2": GroupCounts{Counts{0, 0, 0}, 1, 5, 6, time.Time{}, 7},
 	}
 	c.Check(got1, DeepEquals, want1)
 
 	// Now add a new proc p3 to g2, and increment p1/p2's metrics.
-	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6}
-	p2.ProcMetrics = ProcMetrics{4, 5, 6, 7, 8}
-	p3 := newProc(3, "g2", ProcMetrics{1, 1, 1, 1, 1})
+	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6, 7}
+	p2.ProcMetrics = ProcMetrics{4, 5, 6, 7, 8, 9}
+	p3 := newProc(3, "g2", ProcMetrics{1, 1, 1, 1, 1, 1})
 	_, err = gr.Update(procInfoIter(p1, p2, p3))
 	c.Assert(err, IsNil)
 
 	got2 := gr.Groups()
 	want2 := GroupCountMap{
-		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}},
-		"g2": GroupCounts{Counts{2, 2, 2}, 2, 8, 9, time.Time{}},
+		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}, 7},
+		"g2": GroupCounts{Counts{2, 2, 2}, 2, 8, 9, time.Time{}, 10},
 	}
 	c.Check(got2, DeepEquals, want2)
 
 	// Now update p3's metrics and kill p2.
-	p3.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6}
+	p3.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6, 7}
 	_, err = gr.Update(procInfoIter(p1, p3))
 	c.Assert(err, IsNil)
 
 	got3 := gr.Groups()
 	want3 := GroupCountMap{
-		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}},
-		"g2": GroupCounts{Counts{3, 4, 5}, 1, 5, 6, time.Time{}},
+		"g1": GroupCounts{Counts{1, 1, 1}, 1, 5, 6, time.Time{}, 7},
+		"g2": GroupCounts{Counts{3, 4, 5}, 1, 5, 6, time.Time{}, 7},
 	}
 	c.Check(got3, DeepEquals, want3, Commentf("diff %s", pretty.Compare(got3, want3)))
 
 	// Now update p3's metrics and kill p1.
-	p3.ProcMetrics = ProcMetrics{4, 4, 4, 2, 1}
+	p3.ProcMetrics = ProcMetrics{4, 4, 4, 2, 1, 0}
 	_, err = gr.Update(procInfoIter(p3))
 	c.Assert(err, IsNil)
 
 	got4 := gr.Groups()
 	want4 := GroupCountMap{
-		"g1": GroupCounts{Counts{1, 1, 1}, 0, 0, 0, time.Time{}},
-		"g2": GroupCounts{Counts{5, 5, 5}, 1, 2, 1, time.Time{}},
+		"g1": GroupCounts{Counts{1, 1, 1}, 0, 0, 0, time.Time{}, 0},
+		"g2": GroupCounts{Counts{5, 5, 5}, 1, 2, 1, time.Time{}, 0},
 	}
 	c.Check(got4, DeepEquals, want4, Commentf("diff %s\n%s", pretty.Compare(got4, want4), pretty.Sprint(gr)))
 

--- a/proc/read.go
+++ b/proc/read.go
@@ -35,6 +35,7 @@ type (
 		WriteBytes    uint64
 		ResidentBytes uint64
 		VirtualBytes  uint64
+		OpenFDs       uint64
 	}
 
 	ProcIdStatic struct {
@@ -249,12 +250,17 @@ func (p proc) GetMetrics() (ProcMetrics, error) {
 	if err != nil {
 		return ProcMetrics{}, err
 	}
+	fds, err := p.Proc.FileDescriptors()
+	if err != nil {
+		return ProcMetrics{}, err
+	}
 	return ProcMetrics{
 		CpuTime:       stat.CPUTime(),
 		ReadBytes:     io.ReadBytes,
 		WriteBytes:    io.WriteBytes,
 		ResidentBytes: uint64(stat.ResidentMemory()),
 		VirtualBytes:  uint64(stat.VirtualMemory()),
+		OpenFDs:       uint64(len(fds)),
 	}, nil
 }
 

--- a/proc/tracker.go
+++ b/proc/tracker.go
@@ -17,6 +17,9 @@ type (
 		Resident uint64
 		Virtual  uint64
 	}
+	Filedesc struct {
+		Open uint64
+	}
 
 	// Tracker tracks processes and records metrics.
 	Tracker struct {
@@ -53,8 +56,8 @@ func (tp *TrackedProc) GetCmdLine() []string {
 	return tp.info.Cmdline
 }
 
-func (tp *TrackedProc) GetStats() (aggregate, latest Counts, mem Memory, start time.Time) {
-	return tp.accum, tp.lastaccum, Memory{Resident: tp.info.ResidentBytes, Virtual: tp.info.VirtualBytes}, tp.info.StartTime
+func (tp *TrackedProc) GetStats() (aggregate, latest Counts, mem Memory, fds Filedesc, start time.Time) {
+	return tp.accum, tp.lastaccum, Memory{Resident: tp.info.ResidentBytes, Virtual: tp.info.VirtualBytes}, Filedesc{Open: tp.info.OpenFDs}, tp.info.StartTime
 }
 
 func NewTracker() *Tracker {

--- a/proc/tracker_test.go
+++ b/proc/tracker_test.go
@@ -60,7 +60,7 @@ func (s MySuite) TestTrackerCounts(c *C) {
 	tr := NewTracker()
 
 	// Test that p1 is seen as new
-	p1 := newProc(1, 1, "p1", ProcMetrics{1, 2, 3, 4, 5})
+	p1 := newProc(1, 1, "p1", ProcMetrics{1, 2, 3, 4, 5, 6})
 	want1 := []ProcIdInfo{p1}
 	got1, _, err := tr.Update(procInfoIter(p1))
 	c.Assert(err, IsNil)
@@ -73,7 +73,7 @@ func (s MySuite) TestTrackerCounts(c *C) {
 	c.Check(got2, DeepEquals, []ProcIdInfo(nil))
 
 	// Now update p1's metrics
-	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6}
+	p1.ProcMetrics = ProcMetrics{2, 3, 4, 5, 6, 7}
 	got3, _, err := tr.Update(procInfoIter(p1))
 	c.Assert(err, IsNil)
 	c.Check(got3, DeepEquals, []ProcIdInfo(nil))
@@ -83,7 +83,7 @@ func (s MySuite) TestTrackerCounts(c *C) {
 	c.Check(tr.Tracked[p1.ProcId].info, DeepEquals, ProcInfo{p1.ProcStatic, p1.ProcMetrics})
 
 	// Now update p1's metrics again
-	p1.ProcMetrics = ProcMetrics{4, 6, 8, 9, 10}
+	p1.ProcMetrics = ProcMetrics{4, 6, 8, 9, 10, 11}
 	got4, _, err := tr.Update(procInfoIter(p1))
 	c.Assert(err, IsNil)
 	c.Check(got4, DeepEquals, []ProcIdInfo(nil))


### PR DESCRIPTION
This adds the number of open file descriptors for a group to the list of
exported metrics.