### PR TITLE
don't run tests when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM golang
 ADD . /go/src/github.com/ncabatoff/process-exporter
 
 # Build the process-exporter command inside the container.
-RUN make -C /go/src/github.com/ncabatoff/process-exporter
+RUN make -C /go/src/github.com/ncabatoff/process-exporter vet build
 
 USER root
 


### PR DESCRIPTION
since TestMissingIo tries to verify that pid 1 doesn't provide I/O or FD stats.
This test fails if pid 1 is owned by the same user running the tests, so for the docker build case...

This should fix #23 (although it would be nicer to still run the remaining tests)...