### PR TITLE
add an option to always recheck process names on each scrape

### DIFF
--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -276,6 +276,8 @@ func main() {
 			"print manual")
 		configPath = flag.String("config.path", "",
 			"path to YAML config file")
+		recheck = flag.Bool("recheck", false,
+			"recheck process names on each scrape")
 	)
 	flag.Parse()
 
@@ -317,7 +319,7 @@ func main() {
 		matchnamer = namemapper
 	}
 
-	pc, err := NewProcessCollector(*procfsPath, *children, *threads, matchnamer)
+	pc, err := NewProcessCollector(*procfsPath, *children, *threads, matchnamer, *recheck)
 	if err != nil {
 		log.Fatalf("Error initializing: %v", err)
 	}
@@ -372,6 +374,7 @@ func NewProcessCollector(
 	children bool,
 	threads bool,
 	n common.MatchNamer,
+	recheck bool,
 ) (*NamedProcessCollector, error) {
 	fs, err := proc.NewFS(procfsPath)
 	if err != nil {
@@ -379,7 +382,7 @@ func NewProcessCollector(
 	}
 	p := &NamedProcessCollector{
 		scrapeChan: make(chan scrapeRequest),
-		Grouper:    proc.NewGrouper(n, children, threads),
+		Grouper:    proc.NewGrouper(n, children, threads, recheck),
 		source:     fs,
 		threads:    threads,
 	}

--- a/proc/grouper.go
+++ b/proc/grouper.go
@@ -60,11 +60,11 @@ func lessThreads(x, y Threads) bool {
 }
 
 // NewGrouper creates a grouper.
-func NewGrouper(namer common.MatchNamer, trackChildren, trackThreads bool) *Grouper {
+func NewGrouper(namer common.MatchNamer, trackChildren, trackThreads, alwaysRecheck bool) *Grouper {
 	g := Grouper{
 		groupAccum:  make(map[string]Counts),
 		threadAccum: make(map[string]map[string]Threads),
-		tracker:     NewTracker(namer, trackChildren, trackThreads),
+		tracker:     NewTracker(namer, trackChildren, trackThreads, alwaysRecheck),
 	}
 	return &g
 }

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -73,7 +73,7 @@ func TestGrouperBasic(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1, n2), false, false)
+	gr := NewGrouper(newNamer(n1, n2), false, false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -128,7 +128,7 @@ func TestGrouperProcJoin(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1), false, false)
+	gr := NewGrouper(newNamer(n1), false, false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -171,7 +171,7 @@ func TestGrouperNonDecreasing(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1), false, false)
+	gr := NewGrouper(newNamer(n1), false, false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -224,7 +224,7 @@ func TestGrouperThreads(t *testing.T) {
 	}
 
 	opts := cmpopts.SortSlices(lessThreads)
-	gr := NewGrouper(newNamer(n), false, true)
+	gr := NewGrouper(newNamer(n), false, true, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.proc))
 		if diff := cmp.Diff(got, tc.want, opts); diff != "" {

--- a/proc/tracker_test.go
+++ b/proc/tracker_test.go
@@ -36,7 +36,7 @@ func TestTrackerBasic(t *testing.T) {
 		},
 	}
 	// Note that n3 should not be tracked according to our namer.
-	tr := NewTracker(newNamer(n1, n2, n4), false, false)
+	tr := NewTracker(newNamer(n1, n2, n4), false, false, false)
 
 	for i, tc := range tests {
 		_, got, err := tr.Update(procInfoIter(tc.procs...))
@@ -94,7 +94,7 @@ func TestTrackerChildren(t *testing.T) {
 		},
 	}
 	// Only n2 and children of n2s should be tracked
-	tr := NewTracker(newNamer(n2), true, false)
+	tr := NewTracker(newNamer(n2), true, false, false)
 
 	for i, tc := range tests {
 		_, got, err := tr.Update(procInfoIter(tc.procs...))
@@ -127,7 +127,7 @@ func TestTrackerMetrics(t *testing.T) {
 				Filedesc{2, 20}, tm, 1, States{Running: 1}, nil},
 		},
 	}
-	tr := NewTracker(newNamer(n), false, false)
+	tr := NewTracker(newNamer(n), false, false, false)
 
 	for i, tc := range tests {
 		_, got, err := tr.Update(procInfoIter(tc.proc))
@@ -185,7 +185,7 @@ func TestTrackerThreads(t *testing.T) {
 			},
 		},
 	}
-	tr := NewTracker(newNamer(n), false, true)
+	tr := NewTracker(newNamer(n), false, true, false)
 
 	opts := cmpopts.SortSlices(lessThreadUpdate)
 	for i, tc := range tests {


### PR DESCRIPTION
This is disabled by default.

Although this is less efficient, it is useful/needed if some processes use exec and
would otherwise be completey ignored when they still have a name that is not supposed
to be tracked when checked for the first time.
E.g. when starting some processes with a wrapper bash script that then `exec`s the actual
process later.

This seems to solve #29 for me.
If you have better ideas for naming this option, let me know...