### PR TITLE
Add account label to process-exporter metrics

### DIFF
--- a/proc/base_test.go
+++ b/proc/base_test.go
@@ -56,7 +56,7 @@ func (n namer) MatchAndName(nacl common.NameAndCmdline) (bool, string) {
 
 func newProcIDStatic(pid, ppid int, startTime uint64, name string, cmdline []string) (ID, Static) {
 	return ID{pid, startTime},
-		Static{name, cmdline, ppid, time.Unix(int64(startTime), 0).UTC()}
+		Static{"", name, cmdline, ppid, time.Unix(int64(startTime), 0).UTC()}
 }
 
 func newProc(pid int, name string, m Metrics) IDInfo {

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -11,7 +11,7 @@ import (
 type grouptest struct {
 	grouper *Grouper
 	procs   Iter
-	want    GroupByName
+	want    GroupById
 }
 
 //func (gt grouptest) run(c *C) {
@@ -22,7 +22,7 @@ type grouptest struct {
 //	c.Check(got, DeepEquals, gt.want, Commentf("diff %s", pretty.Compare(got, gt.want)))
 //}
 
-func rungroup(t *testing.T, gr *Grouper, procs Iter) GroupByName {
+func rungroup(t *testing.T, gr *Grouper, procs Iter) GroupById {
 	_, groups, err := gr.Update(procs)
 	if err != nil {
 		t.Fatalf("group.Update error: %v", err)
@@ -35,45 +35,28 @@ func rungroup(t *testing.T, gr *Grouper, procs Iter) GroupByName {
 // groups: the grouper adds to counts and updates the other tracked metrics like
 // Memory.
 func TestGrouperBasic(t *testing.T) {
-	p1, p2 := 1, 2
-	n1, n2 := "g1", "g2"
+	p1 := 1
+	n1 := "g1"
 	starttime := time.Unix(0, 0).UTC()
+	u := ""
 
 	tests := []struct {
 		procs []IDInfo
-		want  GroupByName
+		want  GroupById
 	}{
 		{
 			[]IDInfo{
 				piinfost(p1, n1, Counts{1, 2, 3, 4, 5, 6}, Memory{7, 8},
 					Filedesc{4, 400}, 2, States{Other: 1}),
-				piinfost(p2, n2, Counts{2, 3, 4, 5, 6, 7}, Memory{8, 9},
-					Filedesc{40, 400}, 3, States{Waiting: 1}),
 			},
-			GroupByName{
-				"g1": Group{Counts{}, States{Other: 1}, 1, Memory{7, 8}, starttime,
+			GroupById{
+				GroupId{u, n1}: Group{Counts{}, States{Other: 1}, 1, Memory{7, 8}, starttime,
 					4, 0.01, 2, nil},
-				"g2": Group{Counts{}, States{Waiting: 1}, 1, Memory{8, 9}, starttime,
-					40, 0.1, 3, nil},
-			},
-		},
-		{
-			[]IDInfo{
-				piinfost(p1, n1, Counts{2, 3, 4, 5, 6, 7},
-					Memory{6, 7}, Filedesc{100, 400}, 4, States{Zombie: 1}),
-				piinfost(p2, n2, Counts{4, 5, 6, 7, 8, 9},
-					Memory{9, 8}, Filedesc{400, 400}, 2, States{Running: 1}),
-			},
-			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1}, States{Zombie: 1}, 1,
-					Memory{6, 7}, starttime, 100, 0.25, 4, nil},
-				"g2": Group{Counts{2, 2, 2, 2, 2, 2}, States{Running: 1}, 1,
-					Memory{9, 8}, starttime, 400, 1, 2, nil},
 			},
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1, n2), false, false)
+	gr := NewGrouper(newNamer(n1), false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -88,17 +71,18 @@ func TestGrouperProcJoin(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g1"
 	starttime := time.Unix(0, 0).UTC()
+	u := ""
 
 	tests := []struct {
 		procs []IDInfo
-		want  GroupByName
+		want  GroupById
 	}{
 		{
 			[]IDInfo{
 				piinfo(p1, n1, Counts{1, 2, 3, 4, 5, 6}, Memory{3, 4}, Filedesc{4, 400}, 2),
 			},
-			GroupByName{
-				"g1": Group{Counts{}, States{}, 1, Memory{3, 4}, starttime, 4, 0.01, 2, nil},
+			GroupById{
+				GroupId{u, n1}: Group{Counts{}, States{}, 1, Memory{3, 4}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			// The counts for pid2 won't be factored into the total yet because we only add
@@ -110,8 +94,8 @@ func TestGrouperProcJoin(t *testing.T) {
 				piinfost(p2, n2, Counts{1, 1, 1, 1, 1, 1},
 					Memory{1, 2}, Filedesc{40, 400}, 3, States{Sleeping: 1}),
 			},
-			GroupByName{
-				"g1": Group{Counts{2, 2, 2, 2, 2, 2}, States{Running: 1, Sleeping: 1}, 2,
+			GroupById{
+				GroupId{u, n1}: Group{Counts{2, 2, 2, 2, 2, 2}, States{Running: 1, Sleeping: 1}, 2,
 					Memory{4, 6}, starttime, 44, 0.1, 5, nil},
 			},
 		}, {
@@ -121,8 +105,8 @@ func TestGrouperProcJoin(t *testing.T) {
 				piinfost(p2, n2, Counts{2, 2, 2, 2, 2, 2},
 					Memory{2, 4}, Filedesc{40, 400}, 3, States{Running: 1}),
 			},
-			GroupByName{
-				"g1": Group{Counts{4, 4, 4, 4, 4, 4}, States{Running: 2}, 2,
+			GroupById{
+				GroupId{u, n2}: Group{Counts{4, 4, 4, 4, 4, 4}, States{Running: 2}, 2,
 					Memory{3, 9}, starttime, 44, 0.1, 5, nil},
 			},
 		},
@@ -143,30 +127,31 @@ func TestGrouperNonDecreasing(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g1"
 	starttime := time.Unix(0, 0).UTC()
+	u := ""
 
 	tests := []struct {
 		procs []IDInfo
-		want  GroupByName
+		want  GroupById
 	}{
 		{
 			[]IDInfo{
 				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8}, Memory{3, 4}, Filedesc{4, 400}, 2),
 				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1}, Memory{1, 2}, Filedesc{40, 400}, 3),
 			},
-			GroupByName{
-				"g1": Group{Counts{}, States{}, 2, Memory{4, 6}, starttime, 44, 0.1, 5, nil},
+			GroupById{
+				GroupId{u, n1}: Group{Counts{}, States{}, 2, Memory{4, 6}, starttime, 44, 0.1, 5, nil},
 			},
 		}, {
 			[]IDInfo{
 				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9}, Memory{1, 5}, Filedesc{4, 400}, 2),
 			},
-			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1}, States{}, 1, Memory{1, 5}, starttime, 4, 0.01, 2, nil},
+			GroupById{
+				GroupId{u, n1}: Group{Counts{1, 1, 1, 1, 1, 1}, States{}, 1, Memory{1, 5}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			[]IDInfo{},
-			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1}, States{}, 0, Memory{}, time.Time{}, 0, 0, 0, nil},
+			GroupById{
+				GroupId{u, n2}: Group{Counts{1, 1, 1, 1, 1, 1}, States{}, 0, Memory{}, time.Time{}, 0, 0, 0, nil},
 			},
 		},
 	}
@@ -182,18 +167,19 @@ func TestGrouperNonDecreasing(t *testing.T) {
 
 func TestGrouperThreads(t *testing.T) {
 	p, n, tm := 1, "g1", time.Unix(0, 0).UTC()
+	u := ""
 
 	tests := []struct {
 		proc IDInfo
-		want GroupByName
+		want GroupById
 	}{
 		{
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
 				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6}},
 				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1}},
 			}),
-			GroupByName{
-				"g1": Group{Counts{}, States{}, 1, Memory{}, tm, 1, 1, 2, []Threads{
+			GroupById{
+				GroupId{u, n}: Group{Counts{}, States{}, 1, Memory{}, tm, 1, 1, 2, []Threads{
 					Threads{"t1", 1, Counts{}},
 					Threads{"t2", 1, Counts{}},
 				}},
@@ -204,8 +190,8 @@ func TestGrouperThreads(t *testing.T) {
 				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2}},
 				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1}},
 			}),
-			GroupByName{
-				"g1": Group{Counts{}, States{}, 1, Memory{}, tm, 1, 1, 3, []Threads{
+			GroupById{
+				GroupId{u, n}: Group{Counts{}, States{}, 1, Memory{}, tm, 1, 1, 3, []Threads{
 					Threads{"t1", 1, Counts{1, 1, 1, 1, 1, 1}},
 					Threads{"t2", 2, Counts{1, 1, 1, 1, 1, 1}},
 				}},
@@ -215,8 +201,8 @@ func TestGrouperThreads(t *testing.T) {
 				{ThreadID(ID{p + 1, 0}), "t2", Counts{4, 4, 4, 4, 4, 4}},
 				{ThreadID(ID{p + 2, 0}), "t2", Counts{2, 3, 4, 5, 6, 7}},
 			}),
-			GroupByName{
-				"g1": Group{Counts{}, States{}, 1, Memory{}, tm, 1, 1, 2, []Threads{
+			GroupById{
+				GroupId{u, n}: Group{Counts{}, States{}, 1, Memory{}, tm, 1, 1, 2, []Threads{
 					Threads{"t2", 2, Counts{4, 5, 6, 7, 8, 9}},
 				}},
 			},

--- a/proc/tracker.go
+++ b/proc/tracker.go
@@ -63,6 +63,8 @@ type (
 
 	// Update reports on the latest stats for a process.
 	Update struct {
+		// Account is a system account name a owning a process.
+		Account string
 		// GroupName is the name given by the namer to the process.
 		GroupName string
 		// Latest is how much the counts increased since last cycle.
@@ -135,6 +137,7 @@ func lessCounts(x, y Counts) bool {
 
 func (tp *trackedProc) getUpdate() Update {
 	u := Update{
+		Account:    tp.static.Account,
 		GroupName:  tp.groupName,
 		Latest:     tp.lastaccum,
 		Memory:     tp.metrics.Memory,


### PR DESCRIPTION
We've found very useful account username attribution in certain use-cases.

This change extends process grouping not only by supplied name via config but also by a process owner account name.

I'm not sure how well this change is aligned with `process-exporter` philosophy but having `account` label allow us to avoid having lots of code in `process-exporter` configs and/or Prometheus re-naming/labeling configuration.

WDYT ?