### PR TITLE
Dockerfile: multi-stage build for smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM golang
+FROM golang AS build
 
 # Copy the local package files to the container's workspace.
 ADD . /go/src/github.com/ncabatoff/process-exporter
@@ -8,10 +8,13 @@ ADD . /go/src/github.com/ncabatoff/process-exporter
 # Build the process-exporter command inside the container.
 RUN make -C /go/src/github.com/ncabatoff/process-exporter
 
+FROM scratch
+
 USER root
+COPY --from=build /go/src/github.com/ncabatoff/process-exporter/process-exporter /bin/process-exporter
 
 # Run the process-exporter command by default when the container starts.
-ENTRYPOINT ["/go/src/github.com/ncabatoff/process-exporter/process-exporter"]
+ENTRYPOINT ["/bin/process-exporter"]
 
 # Document that the service listens on port 9256.
 EXPOSE 9256

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN make -C /go/src/github.com/ncabatoff/process-exporter
 
 FROM scratch
 
-USER root
 COPY --from=build /go/src/github.com/ncabatoff/process-exporter/process-exporter /bin/process-exporter
 
 # Run the process-exporter command by default when the container starts.


### PR DESCRIPTION
Use multi-stage build, i.e., create a container with golang to build the
code, then create another container to copy the binary. All this from a
single Dockerfile. For details cf.
https://docs.docker.com/develop/develop-images/multistage-build/
Requires a recent version of Docker (17.05 or higher).

Reduces image size from ~830MB to ~12MB.