### PR TITLE
Fix CPU metric naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,9 @@ the label `groupname`.
 
 Number of processes in this group.
 
-### cpu_user_seconds_total counter
+### cpu_seconds_total counter
 
-CPU usage based on /proc/[pid]/stat field utime(14) i.e. user time.
-A value of 1 indicates that the processes in this group have been scheduled
-in user mode for a total of 1 second on a single virtual CPU.
-
-### cpu_system_seconds_total counter
-
-CPU usage based on /proc/[pid]/stat field stime(15) i.e. system time.
+CPU usage based on /proc/[pid]/stat fields utime(14) and stime(15) i.e. user and system time. This is similar to the node\_exporter's `node_cpu_seconds_total`.
 
 ### read_bytes_total counter
 

--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -73,16 +73,10 @@ var (
 		[]string{"groupname"},
 		nil)
 
-	cpuUserSecsDesc = prometheus.NewDesc(
-		"namedprocess_namegroup_cpu_user_seconds_total",
+	cpuSecsDesc = prometheus.NewDesc(
+		"namedprocess_namegroup_cpu_seconds_total",
 		"Cpu user usage in seconds",
-		[]string{"groupname"},
-		nil)
-
-	cpuSystemSecsDesc = prometheus.NewDesc(
-		"namedprocess_namegroup_cpu_system_seconds_total",
-		"Cpu system usage in seconds",
-		[]string{"groupname"},
+		[]string{"groupname", "mode"},
 		nil)
 
 	readBytesDesc = prometheus.NewDesc(
@@ -434,8 +428,7 @@ func NewProcessCollector(
 
 // Describe implements prometheus.Collector.
 func (p *NamedProcessCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- cpuUserSecsDesc
-	ch <- cpuSystemSecsDesc
+	ch <- cpuSecsDesc
 	ch <- numprocsDesc
 	ch <- readBytesDesc
 	ch <- writeBytesDesc
@@ -497,10 +490,10 @@ func (p *NamedProcessCollector) scrape(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue, float64(gcounts.OpenFDs), gname)
 			ch <- prometheus.MustNewConstMetric(worstFDRatioDesc,
 				prometheus.GaugeValue, float64(gcounts.WorstFDratio), gname)
-			ch <- prometheus.MustNewConstMetric(cpuUserSecsDesc,
-				prometheus.CounterValue, gcounts.CPUUserTime, gname)
-			ch <- prometheus.MustNewConstMetric(cpuSystemSecsDesc,
-				prometheus.CounterValue, gcounts.CPUSystemTime, gname)
+			ch <- prometheus.MustNewConstMetric(cpuSecsDesc,
+				prometheus.CounterValue, gcounts.CPUUserTime, gname, "user")
+			ch <- prometheus.MustNewConstMetric(cpuSecsDesc,
+				prometheus.CounterValue, gcounts.CPUSystemTime, gname, "system")
 			ch <- prometheus.MustNewConstMetric(readBytesDesc,
 				prometheus.CounterValue, float64(gcounts.ReadBytes), gname)
 			ch <- prometheus.MustNewConstMetric(writeBytesDesc,


### PR DESCRIPTION
Use a label for `user` and `system` CPU use. This allows for easy
aggregations of total process group CPU use.

```
sum without (mode) (
  rate(namedprocess_namegroup_cpu_system_seconds_total[1m])
)
```