### PR TITLE
added a 'report missing' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Prometheus exporter that mines /proc to report on selected processes.
 [![Release](https://img.shields.io/github/release/ncabatoff/process-exporter.svg?style=flat-square")][release]
 [![Powered By: GoReleaser](https://img.shields.io/badge/powered%20by-goreleaser-green.svg?branch=master)](https://github.com/goreleaser)
 [![CircleCI](https://circleci.com/gh/ncabatoff/process-exporter.svg?style=shield)](https://circleci.com/gh/ncabatoff/process-exporter)
+
 Some apps are impractical to instrument directly, either because you
 don't control the code or they're written in a language that isn't easy to
 instrument with Prometheus.  We must instead resort to mining /proc.
@@ -49,6 +50,11 @@ it's assumed its proper name.
 
 -procnames is intended as a quick alternative to using a config file.  Details
 in the following section.
+
+-report.missing will report any processes that are not running the process-exporter
+is started as having "num_procs" of zero. You need to use a config file for this to
+work. It will use the "name" field first and if this is not defined it extracts the
+process names from the "comm" and "exe" arrays.
 
 ## Configuration and group naming
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,7 @@ process_names:
   - exe: 
     - /bin/ksh
 `
-	cfg, err := GetConfig(yml, false)
+	cfg, _, err := GetConfig(yml, false)
 	c.Assert(err, IsNil)
 	c.Check(cfg.MatchNamers.matchers, HasLen, 3)
 
@@ -61,7 +61,7 @@ process_names:
     - prometheus
     name: "{{.ExeFull}}"
 `
-	cfg, err := GetConfig(yml, false)
+	cfg, _, err := GetConfig(yml, false)
 	c.Assert(err, IsNil)
 	c.Check(cfg.MatchNamers.matchers, HasLen, 2)
 
@@ -74,4 +74,25 @@ process_names:
 	found, name = cfg.MatchNamers.matchers[1].MatchAndName(pm)
 	c.Check(found, Equals, true)
 	c.Check(name, Equals, "/usr/local/bin/prometheus")
+}
+
+func (s MySuite) TestReportMissingFeature(c *C) {
+	yml := `
+process_names:
+  - comm:
+    - prometheus
+    - grafana
+  - exe:
+    - postmaster
+    - anotherExe
+    cmdline:
+    - "-a -b --verbose"
+  - exe:
+    - yetAnotherExe
+    name: "named_exe"
+  `
+
+	_, processNames, err := GetConfig(yml, false)
+	c.Assert(err, IsNil)
+	c.Check(*processNames, DeepEquals, []string{"prometheus", "grafana", "postmaster", "anotherExe", "named_exe"})
 }


### PR DESCRIPTION
Added a "report.missing" command line option. When enabled this will report processes which are not running when process-exporter is first ran as having a num_procs of zero. E.g. if firefox isn't running when process-exporter is started and "firefox" is in a "comm" section, the following metric will be reported:

> namedprocess_namegroup_num_procs{groupname="firefox"} 0

It uses the "name" field from the process-exporter config file and if the "name" field does not exist it uses all of the process names from the "comm" or "exe" arrays.

This provides a solution to this issue: [https://github.com/ncabatoff/process-exporter/issues/59](https://github.com/ncabatoff/process-exporter/issues/59)