### PR TITLE
Adding ARM architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ builds:
       - arm64
       - ppc64
       - ppc64le
+    goarm:
+      - 6
+      - 7
 archive:
   name_template: "process-exporter-{{ .Version }}.{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
   wrap_in_directory: true


### PR DESCRIPTION
I would like to run the process-exporter on RPi (armv6l, armv7l). It will be great to have the binaries which can run on RPi.