### PR TITLE
Add configuration for systemd service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 process-exporter
+!packaging/default/process-exporter
 load-generator
 integration-tester
 dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,7 @@ nfpm:
     "packaging/process-exporter.service": "/lib/systemd/system/process-exporter.service"
   config_files:
     "packaging/conf/all.yaml": "/etc/process-exporter/all.yaml"
+    "packaging/default/process-exporter": "/etc/default/process-exporter"
   scripts:
     postinstall: "packaging/scripts/postinstall.sh"
     postremove: "packaging/scripts/postremove.sh"

--- a/packaging/default/process-exporter
+++ b/packaging/default/process-exporter
@@ -1,0 +1,1 @@
+OPTIONS="--config.path /etc/process-exporter/all.yaml --web.listen-address=:9256"

--- a/packaging/process-exporter.service
+++ b/packaging/process-exporter.service
@@ -4,7 +4,8 @@ Description=Process Exporter for Prometheus
 [Service]
 User=root
 Type=simple
-ExecStart=/usr/bin/process-exporter --config.path /etc/process-exporter/all.yaml --web.listen-address=:9256
+EnvironmentFile=/etc/default/process-exporter
+ExecStart=/usr/bin/process-exporter $OPTIONS
 KillMode=process
 Restart=always
 


### PR DESCRIPTION
Moves `process-exporter` runtime options from the service file into `/etc/default/process-exporter` configuration file. Although this is not strictly necessary (service file can be copied to `/etc/systemd` and customized), I believe it's cleaner this way. Also, it follows similar approach as [node_exporter](https://github.com/prometheus/node_exporter/tree/master/examples/systemd) does.

Closes #114.