### PR TITLE
Check if systemd is available

### DIFF
--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,3 +1,9 @@
-systemctl daemon-reload
-systemctl enable process-exporter.service
-systemctl restart process-exporter.service
+#!/bin/sh
+# postinstall script for prometheus-process-exporter
+# Script executed after the package is removed.
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+    systemctl enable process-exporter.service
+    systemctl restart process-exporter.service
+fi

--- a/packaging/scripts/postremove.sh
+++ b/packaging/scripts/postremove.sh
@@ -1,1 +1,7 @@
-systemctl daemon-reload
+#!/bin/sh
+# postremove script for prometheus-process-exporter
+# Script executed after the package is removed.
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+fi

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -1,2 +1,8 @@
-systemctl stop process-exporter.service
-systemctl disable process-exporter.service
+#!/bin/sh
+# preremove script for prometheus-process-exporter
+# Script executed after the package is removed.
+
+if [ -d /run/systemd/system ]; then
+    systemctl stop process-exporter.service
+    systemctl disable process-exporter.service
+fi


### PR DESCRIPTION
I am using this exporter with some older Ubuntu versions that do not support systemd. This PR resolves installation issues on < Ubuntu 16.04 by checking for systemd. The node exporter uses the same approach when installing systemd related resources. 