### PR TITLE
Count usage of process start-up

### DIFF
--- a/proc/tracker.go
+++ b/proc/tracker.go
@@ -24,7 +24,7 @@ type (
 		// to allow finding the Tracked entry of a parent process.
 		procIds map[int]ID
 		// firstUpdateAt is the time the first update was run. It allows to
-		// count first usage of a process started between to Update()
+		// count first usage of a process started between two Update() calls
 		firstUpdateAt time.Time
 		// trackChildren makes Tracker track descendants of procs the
 		// namer wanted tracked.


### PR DESCRIPTION
When a process started between two Update(), count the usage between process creation and the first Update() which see it.

This is especially useful for short-lived processes & not too fast gathering (like process lifetime of 1 minutes and metric gathering every 10 seconds), where I had about 15% error in my case:

I'm measuring CPU usage of a PostgreSQL server behind a pgbouncer configured to keep connection 60 seconds (which means that every 60 seconds, the connection is closed & re-opened, which on Postgres means a process is terminated and a new one is re-created).

The real CPU usage is measured using ps --cumulative on parent process (which is a good approximation on long term, and a correct minimal value. Using this does not account CPU usage of currently running child but do count exactly CPU usage of all terminated children).

Without this PR, I have the following delta (over 1h30):
* CPU seconds between two ps: 77 seconds
* CPU seconds between two namedprocess_namegroup_cpu_seconds_total (both user + system): 65.2 seconds
* Error: 11.80 seconds or 15%

Without this PR, I have the following delta (over 30 minutes):
* CPU seconds between two ps: 28 seconds
* CPU seconds between two namedprocess_namegroup_cpu_seconds_total (both user + system): 28.04 seconds
* Error: none :)