### PR TITLE
Fix OPTS arguments

### DIFF
--- a/packaging/process-exporter.service
+++ b/packaging/process-exporter.service
@@ -4,8 +4,8 @@ Description=Process Exporter for Prometheus
 [Service]
 User=root
 Type=simple
-EnvironmentFile=/etc/default/process-exporter
-ExecStart=/usr/bin/process-exporter ${OPTS}
+EnvironmentFile=-/etc/default/process-exporter
+ExecStart=/usr/bin/process-exporter $OPTS
 KillMode=process
 Restart=always
 


### PR DESCRIPTION
Remove `{}` from OPTS env in ExecStart, causes argument to be sent as a
single quote string, rather than expansion of arguments.

Prefix EnvironmentFile with `-` to make it optional.

Signed-off-by: Ben Kochie <superq@gmail.com>