### PR TITLE
Add exporter version metric

### DIFF
--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ncabatoff/process-exporter/proc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	promVersion "github.com/prometheus/common/version"
 )
 
 // Version is set at build time use ldflags.
@@ -276,6 +277,11 @@ func (nmr *nameMapperRegex) MatchAndName(nacl common.ProcAttributes) (bool, stri
 	return false, ""
 }
 
+func init() {
+	promVersion.Version = version
+	prometheus.MustRegister(promVersion.NewCollector("process_exporter"))
+}
+
 func main() {
 	var (
 		listenAddress = flag.String("web.listen-address", ":9256",
@@ -310,7 +316,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("process-exporter version %s\n", version)
+		fmt.Printf("%s\n", promVersion.Print("process-exporter"))
 		os.Exit(0)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/prometheus/client_golang v1.8.0
+	github.com/prometheus/common v0.14.0
 	github.com/prometheus/procfs v0.2.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b
 	gopkg.in/yaml.v2 v2.3.0


### PR DESCRIPTION
Add a standard `process_exporter_build_info` metric to allow monitoring
exporter rollouts. Use the Prometheus common library version handler.

Signed-off-by: Ben Kochie <superq@gmail.com>