### PR TITLE
Include version info in goreleaser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - checkout
       - run: sudo apt-get -qq update
       - run: sudo apt-get install -y rpm
+      - run: echo "export BRANCH=$CIRCLE_BRANCH" >> $BASH_ENV
       - run: curl -sL https://git.io/goreleaser | VERSION=v0.146.0 bash
 
   release_image:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,14 @@ builds:
   - main: cmd/process-exporter/main.go
     binary: process-exporter
     flags: -tags netgo
+    ldflags:
+      - -s -w
+      - -X github.com/prometheus/common/version.Branch={{.Env.BRANCH}}
+      - -X github.com/prometheus/common/version.BuildDate={{.Date}}
+      - -X github.com/prometheus/common/version.BuildUser=goreleaser
+      - -X github.com/prometheus/common/version.Revision={{.FullCommit}}
+      - -X main.version={{.Version}}
+
     goos:
       - linux
     goarch:


### PR DESCRIPTION
Override the default goreleaser ldflags to inject more build version
variables.

Signed-off-by: Ben Kochie <superq@gmail.com>