### PR TITLE
Fix on 32bit arch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.26.0
-	github.com/prometheus/procfs v0.7.1
+	github.com/prometheus/procfs v0.7.3
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.1 h1:TlEtJq5GvGqMykEwWzbZWjjztF86swFhsPix1i0bkgA=
 github.com/prometheus/procfs v0.7.1/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
+github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
Hi, latest version (0.7.8) of this exporter cannot collect proc stat on armv6 (and posible on all other 32 bit platform). Its bug into currently used procfs package, but in last version bug fixed.

Updating procfs package fix this exporter for 32 bit platforms. I tested fix on my armv7 device, after this patch - exporter start working.

This changes fix bug:
https://github.com/prometheus/procfs/compare/v0.7.1...v0.7.3#diff-a1d7bdae8a86539cbde035eaa8ddef778467c826d849ac33a4ec56b067091695R130-R183

Logs before path:
```
Oct 31 10:43:18 radxa.lan process-exporter[3950]: 2021/10/31 10:43:18 error getting proc ID for pid 613: integer overflow on token 3069030400
Oct 31 10:43:18 radxa.lan process-exporter[3950]: 2021/10/31 10:43:18 error getting proc ID for pid 614: integer overflow on token 3069030400
Oct 31 10:43:18 radxa.lan process-exporter[3950]: 2021/10/31 10:43:18 error getting proc ID for pid 615: integer overflow on token 3069030400
```

Logs after path:
```
Oct 31 10:44:20 radxa.lan process-exporter[4362]: 2021/10/31 10:44:20 found new proc: {Pid:1 StartTimeRel:4}:{Name:systemd Cmdline:[/sbi
n/init] Cgroups:[/ / / /init.scope] ParentPid:0 StartTime:2021-10-19 23:48:53.04 +0000 UTC EffectiveUID:0}
Oct 31 10:44:20 radxa.lan process-exporter[4362]: 2021/10/31 10:44:20 found new proc: {Pid:2 StartTimeRel:4}:{Name:kthreadd Cmdline:[] C
groups:[/ / / /] ParentPid:0 StartTime:2021-10-19 23:48:53.04 +0000 UTC EffectiveUID:0}
Oct 31 10:44:20 radxa.lan process-exporter[4362]: 2021/10/31 10:44:20 found new proc: {Pid:3 StartTimeRel:8}:{Name:ksoftirqd/0 Cmdline:[
] Cgroups:[/ / / /] ParentPid:2 StartTime:2021-10-19 23:48:53.08 +0000 UTC EffectiveUID:0}
```