### PR TITLE
Add -recheck-with-time-limit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ as well as group name.
 re-evaluated. This is disabled by default as an optimization, but since
 processes can choose to change their names, this may result in a process
 falling into the wrong group if we happen to see it for the first time before
-it's assumed its proper name.
+it's assumed its proper name. You can use -recheck-with-time-limit to enable this
+feature only for a specific duration after process starts.
 
 -procnames is intended as a quick alternative to using a config file.  Details
 in the following section.

--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -172,6 +172,8 @@ func main() {
 			"path to YAML web config file")
 		recheck = flag.Bool("recheck", false,
 			"recheck process names on each scrape")
+		recheckTimeLimit = flag.Duration("recheck-with-time-limit", 0,
+			"recheck processes only this much time after their start, but no longer.")
 		debug = flag.Bool("debug", false,
 			"log debugging information to stdout")
 		showVersion = flag.Bool("version", false,
@@ -231,15 +233,20 @@ func main() {
 		matchnamer = namemapper
 	}
 
+	if *recheckTimeLimit != 0 {
+		*recheck = true
+	}
+
 	pc, err := collector.NewProcessCollector(
 		collector.ProcessCollectorOption{
-			ProcFSPath:  *procfsPath,
-			Children:    *children,
-			Threads:     *threads,
-			GatherSMaps: *smaps,
-			Namer:       matchnamer,
-			Recheck:     *recheck,
-			Debug:       *debug,
+			ProcFSPath:       *procfsPath,
+			Children:         *children,
+			Threads:          *threads,
+			GatherSMaps:      *smaps,
+			Namer:            matchnamer,
+			Recheck:          *recheck,
+			RecheckTimeLimit: *recheckTimeLimit,
+			Debug:            *debug,
 		},
 	)
 	if err != nil {

--- a/collector/process_collector.go
+++ b/collector/process_collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"log"
+	"time"
 
 	common "github.com/ncabatoff/process-exporter"
 	"github.com/ncabatoff/process-exporter/proc"
@@ -155,13 +156,14 @@ type (
 	}
 
 	ProcessCollectorOption struct {
-		ProcFSPath  string
-		Children    bool
-		Threads     bool
-		GatherSMaps bool
-		Namer       common.MatchNamer
-		Recheck     bool
-		Debug       bool
+		ProcFSPath       string
+		Children         bool
+		Threads          bool
+		GatherSMaps      bool
+		Namer            common.MatchNamer
+		Recheck          bool
+		RecheckTimeLimit time.Duration
+		Debug            bool
 	}
 
 	NamedProcessCollector struct {
@@ -186,7 +188,7 @@ func NewProcessCollector(options ProcessCollectorOption) (*NamedProcessCollector
 	fs.GatherSMaps = options.GatherSMaps
 	p := &NamedProcessCollector{
 		scrapeChan: make(chan scrapeRequest),
-		Grouper:    proc.NewGrouper(options.Namer, options.Children, options.Threads, options.Recheck, options.Debug),
+		Grouper:    proc.NewGrouper(options.Namer, options.Children, options.Threads, options.Recheck, options.RecheckTimeLimit, options.Debug),
 		source:     fs,
 		threads:    options.Threads,
 		smaps:      options.GatherSMaps,

--- a/proc/grouper.go
+++ b/proc/grouper.go
@@ -49,11 +49,11 @@ type (
 func lessThreads(x, y Threads) bool { return seq.Compare(x, y) < 0 }
 
 // NewGrouper creates a grouper.
-func NewGrouper(namer common.MatchNamer, trackChildren, trackThreads, alwaysRecheck, debug bool) *Grouper {
+func NewGrouper(namer common.MatchNamer, trackChildren, trackThreads, recheck bool, recheckTimeLimit time.Duration, debug bool) *Grouper {
 	g := Grouper{
 		groupAccum:  make(map[string]Counts),
 		threadAccum: make(map[string]map[string]Threads),
-		tracker:     NewTracker(namer, trackChildren, alwaysRecheck, debug),
+		tracker:     NewTracker(namer, trackChildren, recheck, recheckTimeLimit, debug),
 		debug:       debug,
 	}
 	return &g

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -73,7 +73,7 @@ func TestGrouperBasic(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1, n2), false, false, false, false)
+	gr := NewGrouper(newNamer(n1, n2), false, false, false, 0, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -128,7 +128,7 @@ func TestGrouperProcJoin(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1), false, false, false, false)
+	gr := NewGrouper(newNamer(n1), false, false, false, 0, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -171,7 +171,7 @@ func TestGrouperNonDecreasing(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1), false, false, false, false)
+	gr := NewGrouper(newNamer(n1), false, false, false, 0, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -224,7 +224,7 @@ func TestGrouperThreads(t *testing.T) {
 	}
 
 	opts := cmpopts.SortSlices(lessThreads)
-	gr := NewGrouper(newNamer(n), false, true, false, false)
+	gr := NewGrouper(newNamer(n), false, true, false, 0, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.proc))
 		if diff := cmp.Diff(got, tc.want, opts); diff != "" {

--- a/proc/tracker_test.go
+++ b/proc/tracker_test.go
@@ -36,7 +36,7 @@ func TestTrackerBasic(t *testing.T) {
 		},
 	}
 	// Note that n3 should not be tracked according to our namer.
-	tr := NewTracker(newNamer(n1, n2, n4), false, false, false)
+	tr := NewTracker(newNamer(n1, n2, n4), false, false, 0, false)
 
 	opts := cmpopts.SortSlices(lessUpdateGroupName)
 	for i, tc := range tests {
@@ -78,7 +78,7 @@ func TestTrackerChildren(t *testing.T) {
 		},
 	}
 	// Only n2 and children of n2s should be tracked
-	tr := NewTracker(newNamer(n2), true, false, false)
+	tr := NewTracker(newNamer(n2), true, false, 0, false)
 
 	for i, tc := range tests {
 		_, got, err := tr.Update(procInfoIter(tc.procs...))
@@ -111,7 +111,7 @@ func TestTrackerMetrics(t *testing.T) {
 				Filedesc{2, 20}, tm, 1, States{Running: 1}, msi{}, nil},
 		},
 	}
-	tr := NewTracker(newNamer(n), false, false, false)
+	tr := NewTracker(newNamer(n), false, false, 0, false)
 
 	for i, tc := range tests {
 		_, got, err := tr.Update(procInfoIter(tc.proc))
@@ -169,7 +169,7 @@ func TestTrackerThreads(t *testing.T) {
 			},
 		},
 	}
-	tr := NewTracker(newNamer(n), false, false, false)
+	tr := NewTracker(newNamer(n), false, false, 0, false)
 
 	opts := cmpopts.SortSlices(lessThreadUpdate)
 	for i, tc := range tests {


### PR DESCRIPTION
process-exporter already supports the `-recheck` flag which makes it run the whole matching logic on each scrape. This is very useful when trying to monitor processes which change their names shortly after start.

Sadly, `-recheck` carries a rather high performance penalty. At the same time, process name changes are very common directly after start, are seldomly expected during usage.

This commit introduces `-recheck-with-time-limit` which rechecks processes `N` seconds after their start and stops doing so afterwards. This combines the accuracy benefits of -recheck with the performance gains of not using `-recheck`.

I'd be glad if this could be accepted. Let me know if you want any changes. Thanks for working on process-exporter! :)