### PR TITLE
fix: ctxswitch calculation for process with threads

### DIFF
--- a/proc/tracker.go
+++ b/proc/tracker.go
@@ -252,17 +252,28 @@ func (t *Tracker) handleProc(proc Proc, updateTime time.Time) (*IDInfo, CollectE
 	}
 	cerrs.Partial += softerrors
 
-	if len(threads) > 0 {
-		metrics.Counts.CtxSwitchNonvoluntary, metrics.Counts.CtxSwitchVoluntary = 0, 0
-		for _, thread := range threads {
-			metrics.Counts.CtxSwitchNonvoluntary += thread.Counts.CtxSwitchNonvoluntary
-			metrics.Counts.CtxSwitchVoluntary += thread.Counts.CtxSwitchVoluntary
-			metrics.States.Add(thread.States)
-		}
-	}
-
 	var newProc *IDInfo
 	if known {
+		if len(threads) > 0 {
+			metrics.Counts.CtxSwitchNonvoluntary, metrics.Counts.CtxSwitchVoluntary = last.metrics.CtxSwitchNonvoluntary, last.metrics.CtxSwitchVoluntary
+			ctxSwitchNonvoluntaryDiff, ctxSwitchVoluntaryDiff := uint64(0), uint64(0)
+			for _, thread := range threads {
+
+				if lastThread, knownThread := last.threads[thread.ThreadID]; knownThread {
+					ctxSwitchNonvoluntaryDiff +=
+						thread.Counts.CtxSwitchNonvoluntary - lastThread.accum.CtxSwitchNonvoluntary
+					ctxSwitchVoluntaryDiff +=
+						thread.Counts.CtxSwitchVoluntary - lastThread.accum.CtxSwitchVoluntary
+				} else {
+					ctxSwitchNonvoluntaryDiff += thread.Counts.CtxSwitchNonvoluntary
+					ctxSwitchVoluntaryDiff += thread.Counts.CtxSwitchVoluntary
+				}
+				metrics.States.Add(thread.States)
+
+			}
+			metrics.Counts.CtxSwitchNonvoluntary += ctxSwitchNonvoluntaryDiff
+			metrics.Counts.CtxSwitchVoluntary += ctxSwitchVoluntaryDiff
+		}
 		last.update(metrics, updateTime, &cerrs, threads)
 	} else {
 		static, err := proc.GetStatic()
@@ -272,6 +283,16 @@ func (t *Tracker) handleProc(proc Proc, updateTime time.Time) (*IDInfo, CollectE
 			}
 			return nil, cerrs
 		}
+
+		if len(threads) > 0 {
+			metrics.Counts.CtxSwitchNonvoluntary, metrics.Counts.CtxSwitchVoluntary = 0, 0
+			for _, thread := range threads {
+				metrics.Counts.CtxSwitchNonvoluntary += thread.Counts.CtxSwitchNonvoluntary
+				metrics.Counts.CtxSwitchVoluntary += thread.Counts.CtxSwitchVoluntary
+				metrics.States.Add(thread.States)
+			}
+		}
+
 		newProc = &IDInfo{procID, static, metrics, threads}
 		if t.debug {
 			log.Printf("found new proc: %s", newProc)

--- a/proc/tracker_test.go
+++ b/proc/tracker_test.go
@@ -134,10 +134,10 @@ func TestTrackerThreads(t *testing.T) {
 			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 1, States{}, msi{}, nil},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6, 1, 1}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 1, 1}, "", States{}},
 			}),
-			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 2, States{}, msi{},
+			Update{n, Delta{0, 0, 0, 0, 0, 0, 2, 2}, Memory{}, Filedesc{1, 1}, tm, 2, States{}, msi{},
 				[]ThreadUpdate{
 					{"t1", Delta{}},
 					{"t2", Delta{}},
@@ -145,11 +145,11 @@ func TestTrackerThreads(t *testing.T) {
 			},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 1, 1}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2, 1, 1}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 1, 1}, "", States{}},
 			}),
-			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 3, States{}, msi{},
+			Update{n, Delta{0, 0, 0, 0, 0, 0, 1, 1}, Memory{}, Filedesc{1, 1}, tm, 3, States{}, msi{},
 				[]ThreadUpdate{
 					{"t1", Delta{1, 1, 1, 1, 1, 1, 0, 0}},
 					{"t2", Delta{1, 1, 1, 1, 1, 1, 0, 0}},
@@ -158,13 +158,24 @@ func TestTrackerThreads(t *testing.T) {
 			},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 2, 3, 4, 5, 6, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 1, 1}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 2, 3, 4, 5, 6, 1, 1}, "", States{}},
 			}),
 			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 2, States{}, msi{},
 				[]ThreadUpdate{
 					{"t1", Delta{}},
 					{"t2", Delta{0, 1, 2, 3, 4, 5, 0, 0}},
+				},
+			},
+		}, {
+			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
+				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 2, 2}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 2, 3, 4, 5, 6, 2, 2}, "", States{}},
+			}),
+			Update{n, Delta{0, 0, 0, 0, 0, 0, 2, 2}, Memory{}, Filedesc{1, 1}, tm, 2, States{}, msi{},
+				[]ThreadUpdate{
+					{"t1", Delta{0, 0, 0, 0, 0, 0, 1, 1}},
+					{"t2", Delta{0, 0, 0, 0, 0, 0, 1, 1}},
 				},
 			},
 		},


### PR DESCRIPTION
This PR is to fix the issue mentioned in https://github.com/ncabatoff/process-exporter/issues/193


