### PR TITLE
tracker: fix ignoring with -children=false

### DIFF
--- a/proc/tracker.go
+++ b/proc/tracker.go
@@ -447,14 +447,15 @@ func (t *Tracker) Update(iter Iter) (CollectErrors, []Update, error) {
 	}
 
 	// Step 2: track any untracked new proc that should be tracked because its parent is tracked.
-	if t.trackChildren {
-		for _, idinfo := range untracked {
-			if _, ok := t.tracked[idinfo.ID]; ok {
-				// Already tracked or ignored in an earlier iteration
-				continue
-			}
-
+	for _, idinfo := range untracked {
+		if _, ok := t.tracked[idinfo.ID]; ok {
+			// Already tracked or ignored in an earlier iteration
+			continue
+		}
+		if t.trackChildren {
 			t.checkAncestry(idinfo, untracked)
+		} else {
+			t.ignore(idinfo.ID, idinfo.Static.StartTime)
 		}
 	}
 


### PR DESCRIPTION
The code path for `-children=false` failed to ignore unmatched processes as that logic was only triggered from checkAncestry(), which isn't called in that case.

Properly ignore all unmatched processes when using `-children=false`.

I've discovered this while tracking down performance problems and thought that `-children=false` should lead to better performance. However, it didn't, because process-exporter continuously kept gathering full metrics (status, io, tasks) from unrelated processes such as PID 1.