### PR TITLE
process-exporter: collect mmap statistics if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ Number of context switches based on /proc/[pid]/status fields voluntary_ctxt_swi
 and nonvoluntary_ctxt_switches.  The extra label `ctxswitchtype` can have two values:
 `voluntary` and `nonvoluntary`.
 
+### mmap_count gauge
+
+If gathering mmaps file is enabled, this indicates the maximum number of mmap entries
+of any process in the group.
+
 ### memory_bytes gauge
 
 Number of bytes of memory used.  The extra label `memtype` can have three values:
@@ -354,6 +359,12 @@ Same as minor_page_faults_total, but broken down per-thread subgroup.
 ### thread_context_switches_total counter
 
 Same as context_switches_total, but broken down per-thread subgroup.
+
+## Global metrics
+
+### max_map_count gauge
+
+If gathering mmaps file is enabled, this metric indicates the global maximum per process.
 
 ## Instrumentation cost
 

--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -163,6 +163,8 @@ func main() {
 			"if a proc is tracked, track with it any children that aren't part of their own group")
 		threads = flag.Bool("threads", true,
 			"report on per-threadname metrics as well")
+		mmaps = flag.Bool("gather-mmaps", true,
+			"gather metrics from maps file, which contains mmap info")
 		smaps = flag.Bool("gather-smaps", true,
 			"gather metrics from smaps file, which contains proportional resident memory size")
 		man = flag.Bool("man", false,
@@ -244,6 +246,7 @@ func main() {
 			ProcFSPath:        *procfsPath,
 			Children:          *children,
 			Threads:           *threads,
+			GatherMMaps:       *mmaps,
 			GatherSMaps:       *smaps,
 			Namer:             matchnamer,
 			Recheck:           *recheck,

--- a/proc/grouper.go
+++ b/proc/grouper.go
@@ -68,6 +68,9 @@ func groupadd(grp Group, ts Update) Group {
 	grp.Memory.ResidentBytes += ts.Memory.ResidentBytes
 	grp.Memory.VirtualBytes += ts.Memory.VirtualBytes
 	grp.Memory.VmSwapBytes += ts.Memory.VmSwapBytes
+	if grp.Memory.MmapCount < ts.Memory.MmapCount {
+		grp.Memory.MmapCount = ts.Memory.MmapCount
+	}
 	grp.Memory.ProportionalBytes += ts.Memory.ProportionalBytes
 	grp.Memory.ProportionalSwapBytes += ts.Memory.ProportionalSwapBytes
 	if ts.Filedesc.Open != -1 {

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -45,30 +45,30 @@ func TestGrouperBasic(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfost(p1, n1, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{7, 8, 0, 0, 0},
+				piinfost(p1, n1, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{7, 8, 0, 0, 0, 0},
 					Filedesc{4, 400}, 2, States{Other: 1}),
-				piinfost(p2, n2, Counts{2, 3, 4, 5, 6, 7, 0, 0}, Memory{8, 9, 0, 0, 0},
+				piinfost(p2, n2, Counts{2, 3, 4, 5, 6, 7, 0, 0}, Memory{8, 9, 0, 0, 0, 0},
 					Filedesc{40, 400}, 3, States{Waiting: 1}),
 			},
 			GroupByName{
-				"g1": Group{Counts{}, States{Other: 1}, msi{}, 1, Memory{7, 8, 0, 0, 0}, starttime,
+				"g1": Group{Counts{}, States{Other: 1}, msi{}, 1, Memory{7, 8, 0, 0, 0, 0}, starttime,
 					4, 0.01, 2, nil},
-				"g2": Group{Counts{}, States{Waiting: 1}, msi{}, 1, Memory{8, 9, 0, 0, 0}, starttime,
+				"g2": Group{Counts{}, States{Waiting: 1}, msi{}, 1, Memory{8, 9, 0, 0, 0, 0}, starttime,
 					40, 0.1, 3, nil},
 			},
 		},
 		{
 			[]IDInfo{
 				piinfost(p1, n1, Counts{2, 3, 4, 5, 6, 7, 0, 0},
-					Memory{6, 7, 0, 0, 0}, Filedesc{100, 400}, 4, States{Zombie: 1}),
+					Memory{6, 7, 0, 0, 0, 0}, Filedesc{100, 400}, 4, States{Zombie: 1}),
 				piinfost(p2, n2, Counts{4, 5, 6, 7, 8, 9, 0, 0},
-					Memory{9, 8, 0, 0, 0}, Filedesc{400, 400}, 2, States{Running: 1}),
+					Memory{9, 8, 0, 0, 0, 0}, Filedesc{400, 400}, 2, States{Running: 1}),
 			},
 			GroupByName{
 				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{Zombie: 1}, msi{}, 1,
-					Memory{6, 7, 0, 0, 0}, starttime, 100, 0.25, 4, nil},
+					Memory{6, 7, 0, 0, 0, 0}, starttime, 100, 0.25, 4, nil},
 				"g2": Group{Counts{2, 2, 2, 2, 2, 2, 0, 0}, States{Running: 1}, msi{}, 1,
-					Memory{9, 8, 0, 0, 0}, starttime, 400, 1, 2, nil},
+					Memory{9, 8, 0, 0, 0, 0}, starttime, 400, 1, 2, nil},
 			},
 		},
 	}
@@ -95,10 +95,10 @@ func TestGrouperProcJoin(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfo(p1, n1, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p1, n1, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{3, 4, 0, 0, 0, 0}, Filedesc{4, 400}, 2),
 			},
 			GroupByName{
-				"g1": Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				"g1": Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			// The counts for pid2 won't be factored into the total yet because we only add
@@ -106,24 +106,24 @@ func TestGrouperProcJoin(t *testing.T) {
 			// affected though.
 			[]IDInfo{
 				piinfost(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0},
-					Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2, States{Running: 1}),
+					Memory{3, 4, 0, 0, 0, 0}, Filedesc{4, 400}, 2, States{Running: 1}),
 				piinfost(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0},
-					Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3, States{Sleeping: 1}),
+					Memory{1, 2, 0, 0, 0, 0}, Filedesc{40, 400}, 3, States{Sleeping: 1}),
 			},
 			GroupByName{
 				"g1": Group{Counts{2, 2, 2, 2, 2, 2, 0, 0}, States{Running: 1, Sleeping: 1}, msi{}, 2,
-					Memory{4, 6, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
+					Memory{4, 6, 0, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
 			},
 		}, {
 			[]IDInfo{
 				piinfost(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0},
-					Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2, States{Running: 1}),
+					Memory{1, 5, 0, 0, 0, 0}, Filedesc{4, 400}, 2, States{Running: 1}),
 				piinfost(p2, n2, Counts{2, 2, 2, 2, 2, 2, 0, 0},
-					Memory{2, 4, 0, 0, 0}, Filedesc{40, 400}, 3, States{Running: 1}),
+					Memory{2, 4, 0, 0, 0, 0}, Filedesc{40, 400}, 3, States{Running: 1}),
 			},
 			GroupByName{
 				"g1": Group{Counts{4, 4, 4, 4, 4, 4, 0, 0}, States{Running: 2}, msi{}, 2,
-					Memory{3, 9, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
+					Memory{3, 9, 0, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
 			},
 		},
 	}
@@ -150,18 +150,18 @@ func TestGrouperNonDecreasing(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
-				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
+				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0, 0}, Filedesc{40, 400}, 3),
 			},
 			GroupByName{
-				"g1": Group{Counts{}, States{}, msi{}, 2, Memory{4, 6, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
+				"g1": Group{Counts{}, States{}, msi{}, 2, Memory{4, 6, 0, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
 			},
 		}, {
 			[]IDInfo{
-				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0, 0}, Filedesc{4, 400}, 2),
 			},
 			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			[]IDInfo{},
@@ -193,19 +193,19 @@ func TestGrouperRemoveEmptyGroups(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
-				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
+				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0, 0}, Filedesc{40, 400}, 3),
 			},
 			GroupByName{
-				n1: Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
-				n2: Group{Counts{}, States{}, msi{}, 1, Memory{1, 2, 0, 0, 0}, starttime, 40, 0.1, 3, nil},
+				n1: Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				n2: Group{Counts{}, States{}, msi{}, 1, Memory{1, 2, 0, 0, 0, 0}, starttime, 40, 0.1, 3, nil},
 			},
 		}, {
 			[]IDInfo{
-				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0, 0}, Filedesc{4, 400}, 2),
 			},
 			GroupByName{
-				n1: Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				n1: Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			[]IDInfo{},

--- a/proc/tracker_test.go
+++ b/proc/tracker_test.go
@@ -99,15 +99,15 @@ func TestTrackerMetrics(t *testing.T) {
 		want Update
 	}{
 		{
-			piinfost(p, n, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{7, 8, 0, 0, 0},
+			piinfost(p, n, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{7, 8, 0, 0, 0, 0},
 				Filedesc{1, 10}, 9, States{Sleeping: 1}),
-			Update{n, Delta{}, Memory{7, 8, 0, 0, 0}, Filedesc{1, 10}, tm,
+			Update{n, Delta{}, Memory{7, 8, 0, 0, 0, 0}, Filedesc{1, 10}, tm,
 				9, States{Sleeping: 1}, msi{}, nil},
 		},
 		{
-			piinfost(p, n, Counts{2, 3, 4, 5, 6, 7, 0, 0}, Memory{1, 2, 0, 0, 0},
+			piinfost(p, n, Counts{2, 3, 4, 5, 6, 7, 0, 0}, Memory{1, 2, 0, 0, 0, 0},
 				Filedesc{2, 20}, 1, States{Running: 1}),
-			Update{n, Delta{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0},
+			Update{n, Delta{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0, 0},
 				Filedesc{2, 20}, tm, 1, States{Running: 1}, msi{}, nil},
 		},
 	}


### PR DESCRIPTION
This enables tracking maps per process group, as well as supporting alerts based on what % of the max a group is using.