### PR TITLE
Update go version as a fix to CVEs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.22'
+          go-version: '1.23.1'
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.23.1'
 
       - run: make test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS build
 ARG TARGETARCH
 ARG BUILDPLATFORM
 WORKDIR /go/src/github.com/ncabatoff/process-exporter

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ docker:
 	docker run --rm --volumes-from configs "$(DOCKER_IMAGE_NAME):$(TAG_VERSION)" $(SMOKE_TEST)
 
 dockertest:
-	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.22  make -C /go/src/github.com/ncabatoff/process-exporter test
+	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.23.1  make -C /go/src/github.com/ncabatoff/process-exporter test
 
 dockerinteg:
-	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.22  make -C /go/src/github.com/ncabatoff/process-exporter build integ
+	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.23.1  make -C /go/src/github.com/ncabatoff/process-exporter build integ
 
 .PHONY: update-go-deps
 update-go-deps:


### PR DESCRIPTION
Opening this PR to update the go language version as a fix to https://github.com/ncabatoff/process-exporter/issues/318. 