### PR TITLE
Added 'collector.disable-go-runtime-metrics' flag

### DIFF
--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
@@ -140,9 +141,12 @@ func (nmr *nameMapperRegex) MatchAndName(nacl common.ProcAttributes) (bool, stri
 	return false, ""
 }
 
+// Create a new custom Prometheus registry
+var registry = prometheus.NewRegistry()
+
 func init() {
 	promVersion.Version = version
-	prometheus.MustRegister(verCollector.NewCollector("process_exporter"))
+	registry.MustRegister(verCollector.NewCollector("process_exporter"))
 }
 
 func main() {
@@ -180,6 +184,8 @@ func main() {
 		showVersion = flag.Bool("version", false,
 			"print version information and exit")
 		removeEmptyGroups = flag.Bool("remove-empty-groups", false, "forget process groups with no processes")
+		disableGoMetrics  = flag.Bool("collector.disable-go-runtime-metrics", false,
+			"Disable collection of Go runtime metrics")
 	)
 	flag.Parse()
 
@@ -256,7 +262,11 @@ func main() {
 		log.Fatalf("Error initializing: %v", err)
 	}
 
-	prometheus.MustRegister(pc)
+	registry.MustRegister(pc)
+	if !*disableGoMetrics {
+		// Register Go runtime metrics if the flag is not set
+		registry.MustRegister(collectors.NewGoCollector())
+	}
 
 	if *onceToStdoutDelay != 0 {
 		// We throw away the first result because that first collection primes the pump, and
@@ -269,7 +279,7 @@ func main() {
 		return
 	}
 
-	http.Handle(*metricsPath, promhttp.Handler())
+	http.Handle(*metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>


### PR DESCRIPTION
This flag controls go runtime metrics collection by the exporter.
The default scenario is collecting the go runtime metrics using the default go Prometheus client, using this flag means we want to disable collection. It defaults to false.