### PR TITLE
add support for inode notification watches

### DIFF
--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -163,6 +163,8 @@ func main() {
 			"if a proc is tracked, track with it any children that aren't part of their own group")
 		threads = flag.Bool("threads", true,
 			"report on per-threadname metrics as well")
+		inotify = flag.Bool("gather-inotify-watches", true,
+			"gather metrics for registered inode notification watches")
 		smaps = flag.Bool("gather-smaps", true,
 			"gather metrics from smaps file, which contains proportional resident memory size")
 		man = flag.Bool("man", false,
@@ -241,15 +243,16 @@ func main() {
 
 	pc, err := collector.NewProcessCollector(
 		collector.ProcessCollectorOption{
-			ProcFSPath:        *procfsPath,
-			Children:          *children,
-			Threads:           *threads,
-			GatherSMaps:       *smaps,
-			Namer:             matchnamer,
-			Recheck:           *recheck,
-			RecheckTimeLimit:  *recheckTimeLimit,
-			Debug:             *debug,
-			RemoveEmptyGroups: *removeEmptyGroups,
+			ProcFSPath:           *procfsPath,
+			Children:             *children,
+			Threads:              *threads,
+			GatherInotifyWatches: *inotify,
+			GatherSMaps:          *smaps,
+			Namer:                matchnamer,
+			Recheck:              *recheck,
+			RecheckTimeLimit:     *recheckTimeLimit,
+			Debug:                *debug,
+			RemoveEmptyGroups:    *removeEmptyGroups,
 		},
 	)
 	if err != nil {

--- a/fixtures/14804/fdinfo/0
+++ b/fixtures/14804/fdinfo/0
@@ -1,0 +1,4 @@
+pos:	0
+flags:	0100002
+mnt_id:	25
+ino:	20

--- a/fixtures/14804/fdinfo/1
+++ b/fixtures/14804/fdinfo/1
@@ -1,0 +1,5 @@
+pos:	0
+flags:	02
+mnt_id:	10
+ino:	8767
+scm_fds: 0

--- a/fixtures/14804/fdinfo/10
+++ b/fixtures/14804/fdinfo/10
@@ -1,0 +1,5 @@
+pos:	0
+flags:	02000000
+mnt_id:	17
+ino:	1119
+inotify wd:1 ino:19e4 sdev:17 mask:300 ignored_mask:0 fhandle-bytes:c fhandle-type:81 f_handle:e41900000000000001000000

--- a/fixtures/14804/fdinfo/2
+++ b/fixtures/14804/fdinfo/2
@@ -1,0 +1,5 @@
+pos:	0
+flags:	02
+mnt_id:	10
+ino:	8767
+scm_fds: 0

--- a/fixtures/14804/fdinfo/3
+++ b/fixtures/14804/fdinfo/3
@@ -1,0 +1,7 @@
+pos:	0
+flags:	02004002
+mnt_id:	17
+ino:	1119
+eventfd-count:                0
+eventfd-id: 7
+eventfd-semaphore: 0

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -45,9 +45,9 @@ func TestGrouperBasic(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfost(p1, n1, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{7, 8, 0, 0, 0},
+				piinfost(p1, n1, Counts{1, 2, 3, 4, 5, 6, 7, 0, 0}, Memory{7, 8, 0, 0, 0},
 					Filedesc{4, 400}, 2, States{Other: 1}),
-				piinfost(p2, n2, Counts{2, 3, 4, 5, 6, 7, 0, 0}, Memory{8, 9, 0, 0, 0},
+				piinfost(p2, n2, Counts{2, 3, 4, 5, 6, 7, 8, 0, 0}, Memory{8, 9, 0, 0, 0},
 					Filedesc{40, 400}, 3, States{Waiting: 1}),
 			},
 			GroupByName{
@@ -59,15 +59,15 @@ func TestGrouperBasic(t *testing.T) {
 		},
 		{
 			[]IDInfo{
-				piinfost(p1, n1, Counts{2, 3, 4, 5, 6, 7, 0, 0},
+				piinfost(p1, n1, Counts{2, 3, 4, 5, 6, 7, 8, 0, 0},
 					Memory{6, 7, 0, 0, 0}, Filedesc{100, 400}, 4, States{Zombie: 1}),
-				piinfost(p2, n2, Counts{4, 5, 6, 7, 8, 9, 0, 0},
+				piinfost(p2, n2, Counts{4, 5, 6, 7, 8, 9, 10, 0, 0},
 					Memory{9, 8, 0, 0, 0}, Filedesc{400, 400}, 2, States{Running: 1}),
 			},
 			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{Zombie: 1}, msi{}, 1,
+				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, States{Zombie: 1}, msi{}, 1,
 					Memory{6, 7, 0, 0, 0}, starttime, 100, 0.25, 4, nil},
-				"g2": Group{Counts{2, 2, 2, 2, 2, 2, 0, 0}, States{Running: 1}, msi{}, 1,
+				"g2": Group{Counts{2, 2, 2, 2, 2, 2, 2, 0, 0}, States{Running: 1}, msi{}, 1,
 					Memory{9, 8, 0, 0, 0}, starttime, 400, 1, 2, nil},
 			},
 		},
@@ -95,7 +95,7 @@ func TestGrouperProcJoin(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfo(p1, n1, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p1, n1, Counts{1, 2, 3, 4, 5, 6, 7, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
 			},
 			GroupByName{
 				"g1": Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
@@ -105,24 +105,24 @@ func TestGrouperProcJoin(t *testing.T) {
 			// to counts starting with the second time we see a proc. Memory and FDs are
 			// affected though.
 			[]IDInfo{
-				piinfost(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0},
+				piinfost(p1, n1, Counts{3, 4, 5, 6, 7, 8, 9, 0, 0},
 					Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2, States{Running: 1}),
-				piinfost(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0},
+				piinfost(p2, n2, Counts{1, 1, 1, 1, 1, 1, 1, 0, 0},
 					Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3, States{Sleeping: 1}),
 			},
 			GroupByName{
-				"g1": Group{Counts{2, 2, 2, 2, 2, 2, 0, 0}, States{Running: 1, Sleeping: 1}, msi{}, 2,
+				"g1": Group{Counts{2, 2, 2, 2, 2, 2, 2, 0, 0}, States{Running: 1, Sleeping: 1}, msi{}, 2,
 					Memory{4, 6, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
 			},
 		}, {
 			[]IDInfo{
-				piinfost(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0},
+				piinfost(p1, n1, Counts{4, 5, 6, 7, 8, 9, 10, 0, 0},
 					Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2, States{Running: 1}),
-				piinfost(p2, n2, Counts{2, 2, 2, 2, 2, 2, 0, 0},
+				piinfost(p2, n2, Counts{2, 2, 2, 2, 2, 2, 2, 0, 0},
 					Memory{2, 4, 0, 0, 0}, Filedesc{40, 400}, 3, States{Running: 1}),
 			},
 			GroupByName{
-				"g1": Group{Counts{4, 4, 4, 4, 4, 4, 0, 0}, States{Running: 2}, msi{}, 2,
+				"g1": Group{Counts{4, 4, 4, 4, 4, 4, 4, 0, 0}, States{Running: 2}, msi{}, 2,
 					Memory{3, 9, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
 			},
 		},
@@ -150,23 +150,23 @@ func TestGrouperNonDecreasing(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
-				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
+				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 9, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
 			},
 			GroupByName{
 				"g1": Group{Counts{}, States{}, msi{}, 2, Memory{4, 6, 0, 0, 0}, starttime, 44, 0.1, 5, nil},
 			},
 		}, {
 			[]IDInfo{
-				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 10, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
 			},
 			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			[]IDInfo{},
 			GroupByName{
-				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, nil, 0, Memory{}, time.Time{}, 0, 0, 0, nil},
+				"g1": Group{Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, States{}, nil, 0, Memory{}, time.Time{}, 0, 0, 0, nil},
 			},
 		},
 	}
@@ -193,8 +193,8 @@ func TestGrouperRemoveEmptyGroups(t *testing.T) {
 	}{
 		{
 			[]IDInfo{
-				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
-				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
+				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 9, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
 			},
 			GroupByName{
 				n1: Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
@@ -202,10 +202,10 @@ func TestGrouperRemoveEmptyGroups(t *testing.T) {
 			},
 		}, {
 			[]IDInfo{
-				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 10, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
 			},
 			GroupByName{
-				n1: Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				n1: Group{Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
 			},
 		}, {
 			[]IDInfo{},
@@ -231,8 +231,8 @@ func TestGrouperThreads(t *testing.T) {
 	}{
 		{
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
 			}),
 			GroupByName{
 				"g1": Group{Counts{}, States{}, msi{}, 1, Memory{}, tm, 1, 1, 2, []Threads{
@@ -242,24 +242,24 @@ func TestGrouperThreads(t *testing.T) {
 			},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 8, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2, 2, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
 			}),
 			GroupByName{
 				"g1": Group{Counts{}, States{}, msi{}, 1, Memory{}, tm, 1, 1, 3, []Threads{
-					Threads{"t1", 1, Counts{1, 1, 1, 1, 1, 1, 0, 0}},
-					Threads{"t2", 2, Counts{1, 1, 1, 1, 1, 1, 0, 0}},
+					Threads{"t1", 1, Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}},
+					Threads{"t2", 2, Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}},
 				}},
 			},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{4, 4, 4, 4, 4, 4, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 2, 0}), "t2", Counts{2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{4, 4, 4, 4, 4, 4, 4, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{2, 3, 4, 5, 6, 7, 8, 0, 0}, "", States{}},
 			}),
 			GroupByName{
 				"g1": Group{Counts{}, States{}, msi{}, 1, Memory{}, tm, 1, 1, 2, []Threads{
-					Threads{"t2", 2, Counts{4, 5, 6, 7, 8, 9, 0, 0}},
+					Threads{"t2", 2, Counts{4, 5, 6, 7, 8, 9, 10, 0, 0}},
 				}},
 			},
 		},

--- a/proc/read_test.go
+++ b/proc/read_test.go
@@ -78,6 +78,7 @@ func TestReadFixture(t *testing.T) {
 			CPUSystemTime:         0.04,
 			ReadBytes:             1814455,
 			WriteBytes:            0,
+			InotifyWatches:        1,
 			MajorPageFaults:       0x2ff,
 			MinorPageFaults:       0x643,
 			CtxSwitchVoluntary:    72,

--- a/proc/tracker_test.go
+++ b/proc/tracker_test.go
@@ -99,15 +99,15 @@ func TestTrackerMetrics(t *testing.T) {
 		want Update
 	}{
 		{
-			piinfost(p, n, Counts{1, 2, 3, 4, 5, 6, 0, 0}, Memory{7, 8, 0, 0, 0},
+			piinfost(p, n, Counts{1, 2, 3, 4, 5, 6, 7, 0, 0}, Memory{7, 8, 0, 0, 0},
 				Filedesc{1, 10}, 9, States{Sleeping: 1}),
 			Update{n, Delta{}, Memory{7, 8, 0, 0, 0}, Filedesc{1, 10}, tm,
 				9, States{Sleeping: 1}, msi{}, nil},
 		},
 		{
-			piinfost(p, n, Counts{2, 3, 4, 5, 6, 7, 0, 0}, Memory{1, 2, 0, 0, 0},
+			piinfost(p, n, Counts{2, 3, 4, 5, 6, 7, 8, 0, 0}, Memory{1, 2, 0, 0, 0},
 				Filedesc{2, 20}, 1, States{Running: 1}),
-			Update{n, Delta{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0},
+			Update{n, Delta{1, 1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0},
 				Filedesc{2, 20}, tm, 1, States{Running: 1}, msi{}, nil},
 		},
 	}
@@ -134,8 +134,8 @@ func TestTrackerThreads(t *testing.T) {
 			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 1, States{}, msi{}, nil},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{1, 2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
 			}),
 			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 2, States{}, msi{},
 				[]ThreadUpdate{
@@ -145,26 +145,26 @@ func TestTrackerThreads(t *testing.T) {
 			},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 8, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 1, 0}), "t2", Counts{2, 2, 2, 2, 2, 2, 2, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 1, 1, 1, 1, 1, 1, 0, 0}, "", States{}},
 			}),
 			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 3, States{}, msi{},
 				[]ThreadUpdate{
-					{"t1", Delta{1, 1, 1, 1, 1, 1, 0, 0}},
-					{"t2", Delta{1, 1, 1, 1, 1, 1, 0, 0}},
+					{"t1", Delta{1, 1, 1, 1, 1, 1, 1, 0, 0}},
+					{"t2", Delta{1, 1, 1, 1, 1, 1, 1, 0, 0}},
 					{"t2", Delta{}},
 				},
 			},
 		}, {
 			piinfot(p, n, Counts{}, Memory{}, Filedesc{1, 1}, []Thread{
-				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
-				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 2, 3, 4, 5, 6, 0, 0}, "", States{}},
+				{ThreadID(ID{p, 0}), "t1", Counts{2, 3, 4, 5, 6, 7, 8, 0, 0}, "", States{}},
+				{ThreadID(ID{p + 2, 0}), "t2", Counts{1, 2, 3, 4, 5, 6, 7, 0, 0}, "", States{}},
 			}),
 			Update{n, Delta{}, Memory{}, Filedesc{1, 1}, tm, 2, States{}, msi{},
 				[]ThreadUpdate{
 					{"t1", Delta{}},
-					{"t2", Delta{0, 1, 2, 3, 4, 5, 0, 0}},
+					{"t2", Delta{0, 1, 2, 3, 4, 5, 6, 0, 0}},
 				},
 			},
 		},


### PR DESCRIPTION
an additional metric which counts inode notification watches from the `fdinfo` area.