### PR TITLE
add USS metric from smaps

### DIFF
--- a/collector/process_collector.go
+++ b/collector/process_collector.go
@@ -314,6 +314,8 @@ func (p *NamedProcessCollector) scrape(ch chan<- prometheus.Metric) {
 					prometheus.GaugeValue, float64(gcounts.Memory.ProportionalBytes), gname, "proportionalResident")
 				ch <- prometheus.MustNewConstMetric(membytesDesc,
 					prometheus.GaugeValue, float64(gcounts.Memory.ProportionalSwapBytes), gname, "proportionalSwapped")
+				ch <- prometheus.MustNewConstMetric(membytesDesc,
+					prometheus.GaugeValue, float64(gcounts.Memory.USSBytes), gname, "uss")
 			}
 
 			if p.threads {

--- a/proc/grouper.go
+++ b/proc/grouper.go
@@ -70,6 +70,7 @@ func groupadd(grp Group, ts Update) Group {
 	grp.Memory.VmSwapBytes += ts.Memory.VmSwapBytes
 	grp.Memory.ProportionalBytes += ts.Memory.ProportionalBytes
 	grp.Memory.ProportionalSwapBytes += ts.Memory.ProportionalSwapBytes
+	grp.Memory.USSBytes += ts.Memory.USSBytes
 	if ts.Filedesc.Open != -1 {
 		grp.OpenFDs += uint64(ts.Filedesc.Open)
 	}

--- a/proc/read.go
+++ b/proc/read.go
@@ -55,6 +55,7 @@ type (
 		VmSwapBytes           uint64
 		ProportionalBytes     uint64
 		ProportionalSwapBytes uint64
+		USSBytes              uint64
 	}
 
 	// Filedesc describes a proc's file descriptor usage and soft limit.
@@ -513,6 +514,7 @@ func (p proc) GetMetrics() (Metrics, int, error) {
 		} else {
 			memory.ProportionalBytes = smaps.Pss
 			memory.ProportionalSwapBytes = smaps.SwapPss
+			memory.USSBytes = smaps.PrivateDirty + smaps.PrivateClean
 		}
 	}
 


### PR DESCRIPTION
Hi, thanks for the work on this project - I've been using it recently to debug a memory leak and it's been very useful.

I noticed that USS metrics were missing though and they seem to go hand-in-hand with PSS, and I saw that it was fairly trivial to add support for it - so I did.

Here's my use case:

Watching memory growth for individual postgres connections over time, we can see Resident and PSS memory increases but USS is staying the same

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/eebe76b0-ad93-4d73-8a34-02ebf5c00a9c" />

I think in this particular context, this is largely okay, and thus, it's quite useful to know that USS is not growing while shared memory is.

Let me know what you think - thanks