### PR TITLE
Fix recheck on processes which are already grouped

### DIFF
--- a/proc/read.go
+++ b/proc/read.go
@@ -116,7 +116,7 @@ type (
 		// GetProcID() returns (pid,starttime), which can be considered a unique process id.
 		GetProcID() (ID, error)
 		// GetStatic() returns various details read from files under /proc/<pid>/.  Technically
-		// name may not be static, but we'll pretend it is.
+		// name may not always be static.
 		GetStatic() (Static, error)
 		// GetMetrics() returns various metrics read from files under /proc/<pid>/.
 		// It returns an error on complete failure.  Otherwise, it returns metrics


### PR DESCRIPTION
`-recheck` already allows process_exporter to put processes which might change name after they start in the right group. However this only works if the initial process name is not matched. In case a matcher catches it early, the process is left in its old group after its name changes.

This can be observed with a generic configuration like this:
```yaml
process_names:
  - name: "{{.Comm}}"
    cmdline:
      - '.+'
```

If a process called `process1` with PID 1234 starts and later execs and changes its name to `process2`, then 1234 remains in the `process1` group even though it should now be in a new `process2` group.

This PR removes the assumption that `GetStatic` is static, and instead retrieves and updates it at each scrape. I believe this should not have any noticeable performance hit?
- if `recheck` (or `recheck-with-time-limit`) is enabled, the process is allowed to change groups after it has started
- if the new process name is no longer matched by the namer, the process is ignored
I'm not sure about that last behavior: is it `Update` the right place to do it? Could it break tracking of child processes?