### PR TITLE
Add cgroup matching

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,10 @@ type (
 		comms map[string]struct{}
 	}
 
+	cgroupMatcher struct {
+		prefixes []string
+	}
+
 	exeMatcher struct {
 		exes map[string]string
 	}
@@ -75,6 +79,10 @@ func (c *commMatcher) String() string {
 		comms = append(comms, cm)
 	}
 	return fmt.Sprintf("comms: %+v", comms)
+}
+
+func (c *cgroupMatcher) String() string {
+	return fmt.Sprintf("cgroups: %+v", c.prefixes)
 }
 
 func (f FirstMatcher) String() string {
@@ -131,6 +139,21 @@ func (m *matchNamer) MatchAndName(nacl common.ProcAttributes) (bool, string) {
 func (m *commMatcher) Match(nacl common.ProcAttributes) bool {
 	_, found := m.comms[nacl.Name]
 	return found
+}
+
+func (m *cgroupMatcher) Match(nacl common.ProcAttributes) bool {
+	// To optimize, we could sort prefixes when we load the config and do
+	// binary search here. But I doubt anyone will have enough cgroup
+	// prefixes to make that worthwhile.
+
+	for _, cg := range nacl.Cgroups {
+		for _, p := range m.prefixes {
+			if strings.HasPrefix(cg, p) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (m *exeMatcher) Match(nacl common.ProcAttributes) bool {
@@ -204,6 +227,7 @@ type MatcherGroup struct {
 	Name         string   `yaml:"name"`
 	CommRules    []string `yaml:"comm"`
 	ExeRules     []string `yaml:"exe"`
+	CgroupRules  []string `yaml:"cgroup"`
 	CmdlineRules []string `yaml:"cmdline"`
 }
 
@@ -232,6 +256,9 @@ func (r MatcherRules) ToConfig() (*Config, error) {
 				}
 			}
 			matchers = append(matchers, &exeMatcher{exes})
+		}
+		if matcher.CgroupRules != nil {
+			matchers = append(matchers, &cgroupMatcher{matcher.CgroupRules})
 		}
 		if matcher.CmdlineRules != nil {
 			var rs []*regexp.Regexp

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
+	"time"
+
 	// "github.com/kylelemons/godebug/pretty"
 	common "github.com/ncabatoff/process-exporter"
 	. "gopkg.in/check.v1"
-	"time"
 )
 
 func (s MySuite) TestConfigBasic(c *C) {
@@ -48,6 +49,58 @@ process_names:
 	found, name = cfg.MatchNamers.matchers[2].MatchAndName(ksh)
 	c.Check(found, Equals, true)
 	c.Check(name, Equals, "ksh")
+}
+
+func (s MySuite) TestConfigCgroups(c *C) {
+	yml := `
+process_names:
+  - cgroup:
+    - "/user.slice"
+  - cgroup:
+    - "/system.slice/docker-"
+  - cgroup:
+    - "/system.slice/docker-8dde.scope/"
+`
+	cfg, err := GetConfig(yml, false)
+	c.Assert(err, IsNil)
+	c.Check(cfg.MatchNamers.matchers, HasLen, 3)
+
+	none := common.ProcAttributes{Name: "none"}
+	empty := common.ProcAttributes{Name: "empty", Cgroups: []string{}}
+	user := common.ProcAttributes{Name: "user", Cgroups: []string{"/user.slice/user-1000.slice/user@1000.service/app.slice/app-shell.scope"}}
+	docker := common.ProcAttributes{Name: "docker", Cgroups: []string{"/system.slice/ssh.service", "/system.slice/docker-8dde.scope"}}
+
+	// /user.slice
+	found, name := cfg.MatchNamers.matchers[0].MatchAndName(none)
+	c.Check(found, Equals, false)
+	found, _ = cfg.MatchNamers.matchers[0].MatchAndName(empty)
+	c.Check(found, Equals, false)
+	found, name = cfg.MatchNamers.matchers[0].MatchAndName(user)
+	c.Check(found, Equals, true)
+	c.Check(name, Equals, "user")
+	found, _ = cfg.MatchNamers.matchers[0].MatchAndName(docker)
+	c.Check(found, Equals, false)
+
+	// /system.slice/docker-
+	found, _ = cfg.MatchNamers.matchers[1].MatchAndName(none)
+	c.Check(found, Equals, false)
+	found, _ = cfg.MatchNamers.matchers[1].MatchAndName(empty)
+	c.Check(found, Equals, false)
+	found, _ = cfg.MatchNamers.matchers[1].MatchAndName(user)
+	c.Check(found, Equals, false)
+	found, name = cfg.MatchNamers.matchers[1].MatchAndName(docker)
+	c.Check(found, Equals, true)
+	c.Check(name, Equals, "docker")
+
+	// /system.slice/docker-8dde.scope/
+	found, _ = cfg.MatchNamers.matchers[2].MatchAndName(none)
+	c.Check(found, Equals, false)
+	found, _ = cfg.MatchNamers.matchers[2].MatchAndName(empty)
+	c.Check(found, Equals, false)
+	found, _ = cfg.MatchNamers.matchers[2].MatchAndName(user)
+	c.Check(found, Equals, false)
+	found, _ = cfg.MatchNamers.matchers[2].MatchAndName(docker)
+	c.Check(found, Equals, false) // No match, tailing slash
 }
 
 func (s MySuite) TestConfigTemplates(c *C) {


### PR DESCRIPTION
### Description
Added support for matching process names based on cgroup path prefixes in the configuration, allowing for more flexible and accurate process identification.

```yaml
process_names:
  - cgroup:
    - "/user.slice"
  - cgroup:
    - "/system.slice/docker-"
  - cgroup:
    - "/system.slice/docker-8dde.scope/"
```

This PR introduces a new matcher type for cgroups, integrates it into the config parsing logic, and provides comprehensive tests to validate the new functionality.

### Design decisions
- Named this `cgroup` not `cgroups` — imo both are equally correct
- Unlike the `cmdline`, all entries in `cgroup` are OR
- It's possible to optimize this algorithm via binary search, but i doubt it will make much difference when there are only few entries in cgroups.

I'm open to change any of this assumptions. 

### Task list
- [x] Tests
- [ ] Update Readme.md (I'll do it after this PR gets green light)